### PR TITLE
Add filename hook and time format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.ci/
+Makefile.main

--- a/factory.go
+++ b/factory.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/onrik/logrus/filename"
 	"github.com/sirupsen/logrus"
@@ -18,9 +17,6 @@ const (
 	DefaultLevel = "info"
 	// DefaultFormat is the format used by LoggerFactory when Format is omitted.
 	DefaultFormat = "text"
-	// DefaultTimeFormat is a handy timestamp (Jan _2 15:04:05.000000)
-	// with microsecond precision
-	DefaultTimeFormat = time.StampMicro
 )
 
 var (
@@ -40,8 +36,7 @@ type LoggerFactory struct {
 	// Format as string, values are "text" or "json", by default "text" is used.
 	// when a terminal is not detected "json" is used instead.
 	Format string
-	// TimeFormat is used for marshaling timestamps,
-	// by default:"Jan _2 15:04:05.000000"
+	// TimeFormat is used for marshaling timestamps
 	TimeFormat string
 	// Fields in JSON format to be used by configured in the new Logger.
 	Fields string
@@ -135,10 +130,6 @@ func (f *LoggerFactory) setDefaultFormat() error {
 		f.Format = DefaultFormat
 	}
 
-	if f.TimeFormat == "" {
-		f.TimeFormat = DefaultTimeFormat
-	}
-
 	f.Format = strings.ToLower(f.Format)
 	if validFormats[f.Format] {
 		return nil
@@ -155,14 +146,7 @@ func (f *LoggerFactory) setDefaultFormat() error {
 }
 
 func (f *LoggerFactory) setHook(l *logrus.Logger) {
-	l.AddHook(filename.NewHook(
-		logrus.DebugLevel,
-		logrus.InfoLevel,
-		logrus.WarnLevel,
-		logrus.ErrorLevel,
-		logrus.FatalLevel,
-		logrus.PanicLevel),
-	)
+	l.AddHook(filename.NewHook(logrus.DebugLevel))
 }
 
 func (f *LoggerFactory) setFields(l *logrus.Logger) (Logger, error) {

--- a/factory_test.go
+++ b/factory_test.go
@@ -11,7 +11,7 @@ import (
 func TestLoggerFactoryNew_TextWithForce(t *testing.T) {
 	require := require.New(t)
 
-	f := &LoggerFactory{Format: "text", ForceFormat: true}
+	f := &LoggerFactory{Format: TextFormat, ForceFormat: true}
 	l, err := f.New()
 	require.NoError(err)
 
@@ -23,7 +23,7 @@ func TestLoggerFactoryNew_TextWithForce(t *testing.T) {
 func TestLoggerFactoryNew_JSON(t *testing.T) {
 	require := require.New(t)
 
-	f := &LoggerFactory{Format: "json", Level: "info"}
+	f := &LoggerFactory{Format: JSONFormat, Level: InfoLevel}
 	l, err := f.New()
 	require.NoError(err)
 
@@ -37,7 +37,7 @@ func TestLoggerFactoryNew_Fields(t *testing.T) {
 	require := require.New(t)
 
 	js := `{"foo":"bar"}`
-	f := &LoggerFactory{Format: "text", Level: "debug", Fields: js}
+	f := &LoggerFactory{Format: TextFormat, Level: DebugLevel, Fields: js}
 	l, err := f.New()
 	require.NoError(err)
 
@@ -57,12 +57,12 @@ func TestLoggerFactoryNew_Error(t *testing.T) {
 	require.Error(err)
 
 	// invalid format
-	f = &LoggerFactory{Level: "info", Format: "qux"}
+	f = &LoggerFactory{Level: InfoLevel, Format: "qux"}
 	_, err = f.New()
 	require.Error(err)
 
 	// invalid json
-	f = &LoggerFactory{Level: "info", Format: "text", Fields: "qux"}
+	f = &LoggerFactory{Level: InfoLevel, Format: TextFormat, Fields: "qux"}
 	_, err = f.New()
 	require.Error(err)
 }
@@ -70,7 +70,7 @@ func TestLoggerFactoryNew_Error(t *testing.T) {
 func TestLoggerFactoryApply(t *testing.T) {
 	require := require.New(t)
 
-	f := &LoggerFactory{Format: "text", ForceFormat: true, Level: "debug"}
+	f := &LoggerFactory{Format: TextFormat, ForceFormat: true, Level: DebugLevel}
 	err := f.ApplyToLogrus()
 	require.NoError(err)
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -45,5 +45,6 @@ func TestLogger_Error(t *testing.T) {
 	logger.Logger.Out = buf
 
 	l.Error(fmt.Errorf("foo"), "qux %d", 42)
-	require.True(strings.HasSuffix(buf.String(), "error=foo\n"))
+	require.True(strings.Contains(buf.String(), "error=foo"))
+	require.True(strings.Contains(buf.String(), "msg=\"qux 42\""))
 }


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

We'll have logs in following format:
`[Apr 24 21:27:59.941421]  INFO foo source=go-log.v0/default.go:40`
`time="Apr 24 21:26:25.286873" level=error msg="qux 42" error=foo source="go-log.v0/logger.go:32"`
...

Main changes:
- customized time format (by default with micro second precision)
- source = filename:linenumber (implemented by logrus hook)