### PR TITLE
Logger.With, New with fields and test detector

### DIFF
--- a/default_test.go
+++ b/default_test.go
@@ -14,12 +14,21 @@ func TestNew(t *testing.T) {
 
 	os.Setenv("LOG_LEVEL", "DEBUG")
 
-	l, err := New()
-	require.NoError(err)
+	l := New(nil)
 
 	logger, ok := l.(*logger)
 	require.True(ok)
 	require.Equal(logrus.DebugLevel, logger.Entry.Logger.Level)
+}
+
+func TestWith(t *testing.T) {
+	require := require.New(t)
+
+	l := With(Fields{"foo": "bar"})
+
+	logger, ok := l.(*logger)
+	require.True(ok)
+	require.Equal(logrus.Fields{"foo": "bar"}, logger.Entry.Data)
 }
 
 func TestInfof_Lazy(t *testing.T) {
@@ -80,6 +89,11 @@ func NewMockLogger() *MockLogger {
 
 func (l *MockLogger) New(f Fields) Logger {
 	l.calledMethods["New"] = f
+	return nil
+}
+
+func (l *MockLogger) With(f Fields) Logger {
+	l.calledMethods["With"] = f
 	return nil
 }
 

--- a/factory_test.go
+++ b/factory_test.go
@@ -12,7 +12,7 @@ func TestLoggerFactoryNew_TextWithForce(t *testing.T) {
 	require := require.New(t)
 
 	f := &LoggerFactory{Format: TextFormat, ForceFormat: true}
-	l, err := f.New()
+	l, err := f.New(nil)
 	require.NoError(err)
 
 	logger, ok := l.(*logger)
@@ -24,7 +24,7 @@ func TestLoggerFactoryNew_JSON(t *testing.T) {
 	require := require.New(t)
 
 	f := &LoggerFactory{Format: JSONFormat, Level: InfoLevel}
-	l, err := f.New()
+	l, err := f.New(nil)
 	require.NoError(err)
 
 	logger, ok := l.(*logger)
@@ -33,12 +33,26 @@ func TestLoggerFactoryNew_JSON(t *testing.T) {
 	require.Equal(logrus.InfoLevel, logger.Entry.Logger.Level)
 }
 
+func TestLoggerFactoryNew_NewFields(t *testing.T) {
+	require := require.New(t)
+
+	f := &LoggerFactory{Format: TextFormat, Level: DebugLevel}
+	l, err := f.New(Fields{"foo": "bar"})
+	require.NoError(err)
+
+	logger, ok := l.(*logger)
+	require.True(ok)
+	require.Equal(logrus.DebugLevel, logger.Entry.Logger.Level)
+	require.Equal(logrus.Fields{"foo": "bar"}, logger.Entry.Data)
+
+}
+
 func TestLoggerFactoryNew_Fields(t *testing.T) {
 	require := require.New(t)
 
 	js := `{"foo":"bar"}`
 	f := &LoggerFactory{Format: TextFormat, Level: DebugLevel, Fields: js}
-	l, err := f.New()
+	l, err := f.New(nil)
 	require.NoError(err)
 
 	logger, ok := l.(*logger)
@@ -53,17 +67,17 @@ func TestLoggerFactoryNew_Error(t *testing.T) {
 
 	// invalid level
 	f := &LoggerFactory{Level: "text"}
-	_, err := f.New()
+	_, err := f.New(nil)
 	require.Error(err)
 
 	// invalid format
 	f = &LoggerFactory{Level: InfoLevel, Format: "qux"}
-	_, err = f.New()
+	_, err = f.New(nil)
 	require.Error(err)
 
 	// invalid json
 	f = &LoggerFactory{Level: InfoLevel, Format: TextFormat, Fields: "qux"}
-	_, err = f.New()
+	_, err = f.New(nil)
 	require.Error(err)
 }
 

--- a/logger.go
+++ b/logger.go
@@ -9,6 +9,10 @@ type Fields map[string]interface{}
 type Logger interface {
 	// New returns a copy of the current logger, adding the given Fields.
 	New(Fields) Logger
+	// With returns a copy of the current logger, adding the given Fields.
+	// Alias of New, must be used with will be call chained with any message
+	// function.
+	With(Fields) Logger
 	// Debugf logs a message at level Debug.
 	Debugf(format string, args ...interface{})
 	// Infof logs a message at level Info.
@@ -27,6 +31,8 @@ func (l *logger) New(f Fields) Logger {
 	e := l.WithFields(logrus.Fields(f))
 	return &logger{*e}
 }
+
+func (l *logger) With(f Fields) Logger { return l.New(f) }
 
 func (l *logger) Errorf(err error, format string, args ...interface{}) {
 	l.WithError(err).Errorf(format, args...)

--- a/logger_test.go
+++ b/logger_test.go
@@ -14,7 +14,7 @@ func TestLoggerNew(t *testing.T) {
 	require := require.New(t)
 
 	f := &LoggerFactory{Format: "text", Level: "debug"}
-	l, err := f.New()
+	l, err := f.New(nil)
 	require.NoError(err)
 
 	l = l.New(Fields{"foo": "qux"})
@@ -31,11 +31,24 @@ func TestLoggerNew(t *testing.T) {
 	}, l2.Entry.Data)
 }
 
+func TestLogger_With(t *testing.T) {
+	require := require.New(t)
+
+	f := &LoggerFactory{Format: "text", Level: "debug"}
+	l, err := f.New(nil)
+	require.NoError(err)
+
+	l = l.With(Fields{"foo": "qux"})
+	l1, ok := l.(*logger)
+	require.True(ok)
+	require.Equal(logrus.Fields{"foo": "qux"}, l1.Entry.Data)
+}
+
 func TestLogger_Errorf(t *testing.T) {
 	require := require.New(t)
 
 	f := &LoggerFactory{Format: "text", Level: "debug"}
-	l, err := f.New()
+	l, err := f.New(nil)
 	require.NoError(err)
 
 	logger, ok := l.(*logger)


### PR DESCRIPTION
After trying the library in a real-life project, I found a couple of improvements to do.

- new method Logger.With
- Logger.New, panics, instead of returning an error, in favor of have a more fluent API
- Logging is disabled if we are running on tests