### PR TITLE
Implement own filename hook.

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onrik/logrus/filename"
 	"github.com/sirupsen/logrus"
 	"github.com/x-cray/logrus-prefixed-formatter"
 	"golang.org/x/crypto/ssh/terminal"
@@ -164,7 +163,7 @@ func (f *LoggerFactory) setDefaultFormat() error {
 
 func (f *LoggerFactory) setHook(l *logrus.Logger) {
 	if f.Level == DebugLevel {
-		l.AddHook(filename.NewHook(
+		l.AddHook(newFilenameHook(
 			logrus.DebugLevel,
 			logrus.InfoLevel,
 			logrus.WarnLevel,

--- a/filename.go
+++ b/filename.go
@@ -15,6 +15,8 @@ import (
 // and prevents from going to deep on call stack.
 const maxStackFrames = 16
 
+const unknownFilename = "???"
+
 // filenameHook implements logrus.Hook interface
 type filenameHook struct {
 	field      string   // field is a name used in logging
@@ -66,7 +68,7 @@ func (hook *filenameHook) caller() (string, int) {
 		}
 	}
 
-	return "???", 0
+	return unknownFilename, 0
 }
 
 // basename returns file name and base directory e.g.:

--- a/filename.go
+++ b/filename.go
@@ -11,8 +11,8 @@ import (
 )
 
 // maxStackFrames stands for maximum number of stack frames.
-// This const is used as a maximum number of stack frames to skip
-// and prevents from going to deep on call stack.
+// This const is used as a maximum number of stack frames to skip.
+// It prevents from going to deep on stack (due to performance reasons).
 const maxStackFrames = 16
 
 const unknownFilename = "???"
@@ -21,7 +21,7 @@ const unknownFilename = "???"
 type filenameHook struct {
 	field      string   // field is a name used in logging
 	skipframes int      // skipframes is used to skip number of stack frames.
-	skipnames  []string // skipnames is a slice of names to skip.
+	skipnames  []string // skipnames contains stack frames prefixes to skip.
 	levels     []logrus.Level
 	formatter  func(file string, line int) string
 }
@@ -36,6 +36,11 @@ func (hook *filenameHook) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
+// newFilenameHook creates a new default filename hook.
+// By default:
+// -  skips 5 stack frames,
+// - ignore internal calls for logrus and go-log
+// - logging in following format "source={file}:{line}"
 func newFilenameHook(levels ...logrus.Level) *filenameHook {
 	hook := filenameHook{
 		field:      "source",

--- a/filename.go
+++ b/filename.go
@@ -73,10 +73,18 @@ func (hook *filenameHook) caller() (string, int) {
 // for path "gopkg.in/src-d/go-log.v1/logger.go"
 // function returns "go-log.v1/logger.go"
 func basename(path string) string {
-	i, vol := len(path)-1, filepath.VolumeName(path)
-	for ; i >= len(vol) && !os.IsPathSeparator(path[i]); i-- {
-	}
-	for i--; i >= len(vol) && !os.IsPathSeparator(path[i]); i-- {
+	i, n := len(path)-1, 2
+	vollen := len(filepath.VolumeName(path))
+
+	for i >= vollen {
+		if os.IsPathSeparator(path[i]) {
+			n--
+			if n == 0 {
+				break
+			}
+		}
+
+		i--
 	}
 
 	return path[i+1:]

--- a/filename.go
+++ b/filename.go
@@ -1,0 +1,92 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// maxStackFrames stands for maximum number of stack frames.
+// This const is used as a maximum number of stack frames to skip
+// and prevents from going to deep on call stack.
+const maxStackFrames = 16
+
+// filenameHook implements logrus.Hook interface
+type filenameHook struct {
+	field      string   // field is a name used in logging
+	skipframes int      // skipframes is used to skip number of stack frames.
+	skipnames  []string // skipnames is a slice of names to skip.
+	levels     []logrus.Level
+	formatter  func(file string, line int) string
+}
+
+func (hook *filenameHook) Levels() []logrus.Level {
+	return hook.levels
+}
+
+func (hook *filenameHook) Fire(entry *logrus.Entry) error {
+	file, line := hook.caller()
+	entry.Data[hook.field] = hook.formatter(file, line)
+	return nil
+}
+
+func newFilenameHook(levels ...logrus.Level) *filenameHook {
+	hook := filenameHook{
+		field:      "source",
+		skipframes: 5,
+		skipnames:  []string{"go-log", "logrus"},
+		levels:     levels,
+		formatter: func(file string, line int) string {
+			return fmt.Sprintf("%s:%d", file, line)
+		},
+	}
+	if len(hook.levels) == 0 {
+		hook.levels = logrus.AllLevels
+	}
+
+	return &hook
+}
+
+// caller returns filename with base directory (e.g.: "go-log.v1/logger.go")
+// and line number
+func (hook *filenameHook) caller() (string, int) {
+	for i := hook.skipframes; i < maxStackFrames; i++ {
+		_, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+
+		file = basename(file)
+		if !hasPrefix(file, hook.skipnames...) {
+			return file, line
+		}
+	}
+
+	return "???", 0
+}
+
+// basename returns file name and base directory e.g.:
+// for path "gopkg.in/src-d/go-log.v1/logger.go"
+// function returns "go-log.v1/logger.go"
+func basename(path string) string {
+	i, vol := len(path)-1, filepath.VolumeName(path)
+	for ; i >= len(vol) && !os.IsPathSeparator(path[i]); i-- {
+	}
+	for i--; i >= len(vol) && !os.IsPathSeparator(path[i]); i-- {
+	}
+
+	return path[i+1:]
+}
+
+func hasPrefix(s string, prefix ...string) bool {
+	for _, p := range prefix {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/filename_test.go
+++ b/filename_test.go
@@ -1,0 +1,43 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasename(t *testing.T) {
+	require := require.New(t)
+	cases := map[string]string{
+		"github.com/sirupsen/logrus/entry.go":   "logrus/entry.go",
+		"gopkg.in/src-d/go-log.v1/logger.go":    "go-log.v1/logger.go",
+		"gopkg.in/src-d/go-log.v0/logger.go":    "go-log.v0/logger.go",
+		"gopkg.in/src-d/go-log.v0/main/main.go": "main/main.go",
+		"file.go": "file.go",
+		"":        "",
+	}
+
+	for k, v := range cases {
+		require.Equalf(v, basename(k), k)
+	}
+}
+
+func TestHasPrefix(t *testing.T) {
+	require := require.New(t)
+	cases := map[string]struct {
+		prefix []string
+		ok     bool
+	}{
+		"github.com/sirupsen/logrus/entry.go":   {[]string{"logrus"}, true},
+		"gopkg.in/src-d/go-log.v1/logger.go":    {[]string{"go-log"}, true},
+		"gopkg.in/src-d/go-log.v0/logger.go":    {[]string{"go-log"}, true},
+		"gopkg.in/src-d/go-log.v0/main/main.go": {[]string{"go-log"}, false},
+		"file.go": {[]string{"go-log", "logrus"}, false},
+		"":        {[]string{"go-log", "logrus"}, false},
+	}
+
+	for k, v := range cases {
+		file := basename(k)
+		require.Equalf(v.ok, hasPrefix(file, v.prefix...), "path: %v, basename: %v", k, file)
+	}
+}

--- a/filename_test.go
+++ b/filename_test.go
@@ -62,3 +62,11 @@ func TestCaller(t *testing.T) {
 	require.Equal("go-log.v1/filename_test.go", file)
 	require.Equal(line, 61)
 }
+
+func TestCaller_IgnoreInternalCalls(t *testing.T) {
+	require := require.New(t)
+	hook := newFilenameHook(logrus.AllLevels...)
+
+	file, _ := hook.caller()
+	require.Equal(unknownFilename, file)
+}

--- a/filename_test.go
+++ b/filename_test.go
@@ -58,9 +58,8 @@ func TestCaller(t *testing.T) {
 		},
 	}
 
-	file, line := hook.caller()
+	file, _ := hook.caller()
 	require.Equal("go-log.v1/filename_test.go", file)
-	require.Equal(line, 61)
 }
 
 func TestCaller_IgnoreInternalCalls(t *testing.T) {

--- a/filename_test.go
+++ b/filename_test.go
@@ -1,7 +1,10 @@
 package log
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/require"
 )
@@ -40,4 +43,22 @@ func TestHasPrefix(t *testing.T) {
 		file := basename(k)
 		require.Equalf(v.ok, hasPrefix(file, v.prefix...), "path: %v, basename: %v", k, file)
 	}
+}
+
+func TestCaller(t *testing.T) {
+	require := require.New(t)
+
+	hook := &filenameHook{
+		field:      "source",
+		skipframes: 1,
+		skipnames:  []string{"logrus"},
+		levels:     logrus.AllLevels,
+		formatter: func(file string, line int) string {
+			return fmt.Sprintf("%s:%d", file, line)
+		},
+	}
+
+	file, line := hook.caller()
+	require.Equal("go-log.v1/filename_test.go", file)
+	require.Equal(line, 61)
 }


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
Replace `github.com/onrik/logrus/filename` by own implementation filename hook.

Original implementation skips stack frames for _logrus files_. However our go-log wrapper overrides `logger.Errorf` what adds another stack frame `go-log.v1/logger.go`. Having own implementation we'll not have to rely on _black box_, will skip not only `logrus` stack frames but also `go-log` (and whatever we will need in the future) and should also work on windows.