### PR TITLE
Implement fluentd logging format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The configuration should be done always using environment variables. The list
 of available variables is:
 
 - `LOG_LEVEL`: Reporting level, values are "info", "debug", "warning" or "error".
-- `LOG_FORMAT`: Format of the log lines, values are "text" or "json", by default "text" is used. unless a terminal can't be detected, in this case, "json" is used instead.
-- `LOG_FIELDS`: Fields in JSON format to be included in all the loggers.
+- `LOG_FORMAT`: Format of the log lines, values are "text", "json" or "fluentd", by default "text" is used. unless a terminal can't be detected, in this case, "json" is used instead.
+- `LOG_FIELDS`: Fields in JSON or fluentd format to be included in all the loggers.
 - `LOG_FORCE_FORMAT`: If true the fact of being in a terminal or not is ignored.
 
 > By default the logging is disabled if go-log is being executed in tests.

--- a/factory.go
+++ b/factory.go
@@ -29,6 +29,8 @@ const (
 	TextFormat = "text"
 	// JSONFormat stands for json logging format.
 	JSONFormat = "json"
+	// FluentdFormat stands for fluentd that can be parsed by Kubernetes and Google Container Engine.
+	FluentdFormat = "fluentd"
 
 	// DefaultLevel is the level used by LoggerFactory when Level is omitted.
 	DefaultLevel = InfoLevel
@@ -42,7 +44,7 @@ var (
 		disabledLevel: true,
 	}
 	validFormats = map[string]bool{
-		TextFormat: true, JSONFormat: true,
+		TextFormat: true, JSONFormat: true, FluentdFormat: true,
 	}
 )
 
@@ -51,10 +53,10 @@ var (
 type LoggerFactory struct {
 	// Level as string, values are "info", "debug", "warning" or "error".
 	Level string
-	// Format as string, values are "text" or "json", by default "text" is used.
+	// Format as string, values are "text", "json" or "fluentnd", by default "text" is used.
 	// when a terminal is not detected "json" is used instead.
 	Format string
-	// Fields in JSON format to be used by configured in the new Logger.
+	// Fields in JSON or fluentd format to be used by configured in the new Logger.
 	Fields string
 	// ForceFormat if true the fact of being in a terminal or not is ignored.
 	ForceFormat bool
@@ -135,6 +137,14 @@ func (f *LoggerFactory) setFormat(l *logrus.Logger) error {
 	case "json":
 		f := new(logrus.JSONFormatter)
 		f.TimestampFormat = time.RFC3339Nano
+		l.Formatter = f
+	case "fluentd":
+		f := new(logrus.JSONFormatter)
+		f.FieldMap = logrus.FieldMap{
+			logrus.FieldKeyTime:  "timestamp",
+			logrus.FieldKeyLevel: "severity",
+			logrus.FieldKeyMsg:   "message",
+		}
 		l.Formatter = f
 	}
 


### PR DESCRIPTION
fix https://github.com/src-d/go-log/issues/12

according to https://cloud.google.com/logging/docs/agent/configuration#special-fields

logs should have:
- 'severity' field to represent log level
- 'message' field containing log text
- 'timestamp' field containg the moment when the error was produced