### PR TITLE
fix text formatter on windows

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -128,7 +129,7 @@ func (f *LoggerFactory) setFormat(l *logrus.Logger) error {
 	switch f.Format {
 	case "text":
 		f := new(prefixed.TextFormatter)
-		f.ForceColors = true
+		f.ForceColors = runtime.GOOS != "windows"
 		f.FullTimestamp = true
 		f.TimestampFormat = time.RFC3339Nano
 		l.Formatter = f


### PR DESCRIPTION
Terminals on windows don't support colors.
In logrus colors are disabled by default on windows in the same way.

Example of currently produced logs:
<img width="1059" alt="Screenshot 2019-04-24 at 18 07 26" src="https://user-images.githubusercontent.com/406916/56751549-a8654b00-6786-11e9-846b-091285317c1f.png">
